### PR TITLE
Kill threads on application reload

### DIFF
--- a/app/steamding.py
+++ b/app/steamding.py
@@ -17,6 +17,7 @@ import queue
 from functools import partial
 
 cfg = configparser.ConfigParser()
+gd_t, sa_t = None, None
 
 def resource_path(relative_path):
     """ Get absolute path to resource, works for dev and for PyInstaller """
@@ -179,8 +180,9 @@ def start_tracking(systrayicon = None):
         gd_t = threading.Thread(target=run_state_machine, args=(persona_name, profile_url, q,))
         sa_t = threading.Thread(target=scrape_achievements_thread, args=(persona_name, profile_url, q,))
 
-        gd_t.start()
-        sa_t.start()
+        if gd_t == None: gd_t.kill()
+        if sa_t == None: sa_t.kill()
+        gd_t, sa_t = gd_t.start(), sa_t.start()
 
         gd_t.join()
         sa_t.join()

--- a/app/steamding.py
+++ b/app/steamding.py
@@ -17,20 +17,16 @@ import queue
 from functools import partial
 
 cfg = configparser.ConfigParser()
+
 gd_t, sa_t = None, None
 
-def resource_path(relative_path):
-    """ Get absolute path to resource, works for dev and for PyInstaller """
-    base_path = getattr(sys, '_MEIPASS', os.path.dirname(os.path.abspath(__file__)))
-    return os.path.join(base_path, relative_path)
-
 def play_notification_sound(systrayicon = None):
-    playsound(resource_path(f"static/sfx/{cfg.get('DEFAULT', 'SFX')}"), False)
+    playsound(f"static/sfx/{cfg.get('DEFAULT', 'SFX')}", False)
 
 def update_config_property(prop, val, systrayicon=None):
     cfg.set('DEFAULT', prop, val)
     
-    with open(resource_path('settings.ini'), 'w') as cfg_file:
+    with open('settings.ini', 'w') as cfg_file:
         cfg.write(cfg_file)
 
 def scrape_game_title(profile_url):
@@ -83,25 +79,30 @@ def get_profile_url(steamid64):
     return res.url
 
 def setup_tray():
-    sfx_tuple = (('Test sound', resource_path('static/img/bell.ico'), play_notification_sound),)
+    sfx_tuple = (('Test sound', 'static/img/bell.ico', play_notification_sound),)
 
-    for sfx_name in os.listdir(resource_path('static/sfx')):
+    for sfx_name in os.listdir('./static/sfx'):
         sfx_tuple = sfx_tuple + ((sfx_name, None, partial(update_config_property, 'SFX', sfx_name)),)
 
+    def reload():
+        gd_t.kill()
+        sa_t.kill()
+        start_tracking()
+
     root = (
-        ('Reload', None, start_tracking),
+        ('Reload', None, reload),
         ('Options', None, (
             ('Change notification', None, sfx_tuple),
             ('Check privacy settings...', None, lambda x: webbrowser.open('https://steamcommunity.com/my/edit/settings')),
-            ('Edit configuration...', None, lambda x: webbrowser.open('.\settings.ini')))),
+            ('Edit configuration...', None, lambda x: webbrowser.open('settings.ini')))),
         ('Help', 'static/img/github.ico', lambda x: webbrowser.open('https://github.com/aquelemiguel/steamding')),
         ('Donate', 'static/img/coffee.ico', lambda x: webbrowser.open('https://paypal.me/aquelemiguel/')))
     
-    systray = SysTrayIcon(resource_path('static/img/logo.ico'), 'steamding', root)
+    systray = SysTrayIcon('static/img/logo.ico', 'steamding', root)
     return systray
 
 def show_toast(header, body, duration = 5):
-    toaster.show_toast(header, body, icon_path=resource_path('static/img/w_logo.ico'), duration=duration, threaded=True)
+    toaster.show_toast(header, body, icon_path='static/img/w_logo.ico', duration=duration, threaded=True)
 
 def run_state_machine(persona_name, profile_url, out_queue):
     title = None
@@ -164,7 +165,7 @@ def scrape_achievements_thread(persona_name, profile_url, in_queue):
 
 
 def start_tracking(systrayicon = None):
-    cfg.read(resource_path('settings.ini'))
+    cfg.read('settings.ini')
     steamid64 = cfg.get('DEFAULT', 'steamid64')
     profile_url = get_profile_url(steamid64)
 
@@ -180,8 +181,6 @@ def start_tracking(systrayicon = None):
         gd_t = threading.Thread(target=run_state_machine, args=(persona_name, profile_url, q,))
         sa_t = threading.Thread(target=scrape_achievements_thread, args=(persona_name, profile_url, q,))
 
-        if gd_t == None: gd_t.kill()
-        if sa_t == None: sa_t.kill()
         gd_t, sa_t = gd_t.start(), sa_t.start()
 
         gd_t.join()


### PR DESCRIPTION
Closes #2 

Declaration of global variables for the needed threads (not scalable but works for the only two needed at the moment):
![image](https://user-images.githubusercontent.com/16060539/64567251-b7bced80-d34f-11e9-8738-a2c2824f8ac3.png)

Reload function performs old thread killing before launching new ones:
![image](https://user-images.githubusercontent.com/16060539/64567255-ba1f4780-d34f-11e9-9330-1e5f00b1be61.png)
